### PR TITLE
Change date type to be custom scalar.

### DIFF
--- a/src/bin/luminol.js
+++ b/src/bin/luminol.js
@@ -9,6 +9,11 @@ import Compiler from '/internal/Compiler';
 
 import createUi from '/internal/ui';
 
+process.on('unhandledRejection', (err) => {
+  console.error(err);
+  process.exit(1);
+});
+
 yargs
   .option('url', {
     description: 'Server url',

--- a/src/internal/ProxyManager/ProxyManager.js
+++ b/src/internal/ProxyManager/ProxyManager.js
@@ -11,7 +11,7 @@ import type {Client} from '/types';
 type Proxy = {
   path: string,
   url: string,
-  createdAt: number,
+  createdAt: Date,
 };
 
 export type Options = {
@@ -152,7 +152,7 @@ class ProxyManager {
       .sort((a, b) => {
         const x = this._getPathPriority(b) - this._getPathPriority(a);
         if (x === 0) {
-          return b.createdAt - a.createdAt;
+          return b.createdAt.getTime() - a.createdAt.getTime();
         }
         return x;
       })

--- a/src/internal/ProxyManager/__tests__/ProxyManager.test.js
+++ b/src/internal/ProxyManager/__tests__/ProxyManager.test.js
@@ -106,12 +106,12 @@ describe('ProxyManager', () => {
     });
     manager.update([
       {
-        createdAt: 1,
+        createdAt: new Date(Date.now() + 0),
         path: '/',
         url: 'http://sooner:0',
       },
       {
-        createdAt: 2,
+        createdAt: new Date(Date.now() + 2),
         path: '/',
         url: 'http://later:0',
       },

--- a/src/internal/apollo/__tests__/resolvers.test.js
+++ b/src/internal/apollo/__tests__/resolvers.test.js
@@ -1,6 +1,38 @@
+import {Kind} from 'graphql/language';
 import resolvers from '/internal/apollo/resolvers';
 
 describe('resolvers', () => {
+  describe('.DateTime', () => {
+    it('should fail on serializing invalid values', () => {
+      expect(() => {
+        resolvers.DateTime.serialize({f: 3});
+      }).toThrow(Error);
+    });
+    it('should fail on serializing invalid dates', () => {
+      expect(() => {
+        resolvers.DateTime.serialize('');
+      }).toThrow(Error);
+    });
+    it('should fail on parsing invalid values', () => {
+      expect(() => {
+        resolvers.DateTime.parseValue({f: 3});
+      }).toThrow(Error);
+    });
+    it('should serialize', () => {
+      expect(resolvers.DateTime.serialize(new Date('2018-01-01')));
+    });
+    it('should parseValue', () => {
+      expect(resolvers.DateTime.parseValue('2018-01-01'));
+    });
+    it('should parseLiteral', () => {
+      expect(
+        resolvers.DateTime.parseLiteral({
+          kind: Kind.STRING,
+          value: '2018-01-01',
+        }),
+      );
+    });
+  });
   describe('.Query', () => {
     describe('.requests', () => {
       it('should work', async () => {

--- a/src/internal/apollo/typeDefs.js
+++ b/src/internal/apollo/typeDefs.js
@@ -1,6 +1,8 @@
 import gql from 'graphql-tag';
 
 const typeDefs = gql`
+  scalar DateTime
+
   enum CompilerStatus {
     COMPILING
     PENDING
@@ -74,7 +76,7 @@ const typeDefs = gql`
     url: String
     enabled: Boolean
     tags: [String]
-    createdAt: Int
+    createdAt: DateTime
   }
 
   type Request {


### PR DESCRIPTION
The GraphQL `Int` type is 32-bit signed which is too small for JS timestamps.
